### PR TITLE
Remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,6 @@
     "postdeploy": "marks -create-db -postgres-url=$DATABASE_URL"
   },
   "env": {
-    "BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go.git",
     "AUTH_USER": {
       "description": "The basic auth username to protect your notes (optionnal)",
       "value": "",


### PR DESCRIPTION
This isn't required because we officially support Go now: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku